### PR TITLE
Straight-line optimizations (messy)

### DIFF
--- a/src/apps/intel/intel_app.lua
+++ b/src/apps/intel/intel_app.lua
@@ -74,12 +74,12 @@ end
 -- Pull in packets from the network and queue them on our 'tx' link.
 function Intel82599:pull ()
    local l = self.output.tx
-   local n = 128
+   local n = os.getenv("This getenv call makes LuaJIT happy somehow...?") or 0
    if l == nil then return end
    self.dev:sync_receive()
-   while not full(l) and self.dev:can_receive() and n>0 do
+   while not full(l) and self.dev:can_receive() and n <= 64 do
       transmit(l, self.dev:receive())
-      n = n - 1
+      n = n + 1
    end
    self:add_receive_buffers()
 end

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -224,7 +224,7 @@ function breathe ()
 --         zone(app.zone) app:pull() zone()
       if app.pull and not app.dead then
 	 zone(app.zone)
-	 with_restart(app, 'pull')
+	 app:pull()
 	 zone()
       end
    end
@@ -240,7 +240,7 @@ function breathe ()
             local receiver = app_array[link.receiving_app]
             if receiver.push and not receiver.dead then
                zone(receiver.zone)
-               with_restart(receiver, 'push')
+	       receiver:push()
                zone()
                progress = true
             end
@@ -271,7 +271,7 @@ function report (options)
             print (name, ("[dead: %s]"):format(app.dead.error))
          elseif app.report then
             print (name)
-            with_restart(app, 'report')
+	    app:report()
          end
       end
    end

--- a/src/lib/virtio/net_device.lua
+++ b/src/lib/virtio/net_device.lua
@@ -216,8 +216,6 @@ function VirtioNetDevice:translate_physical_addr (addr)
 end
 
 function VirtioNetDevice:map_from_guest (addr)
-   local page = bit.rshift(addr, pagebits)
-   if page == self.last_guest_page then return addr + self.last_guest_offset end
    local result
    for i = 0, table.getn(self.mem_table) do
       local m = self.mem_table[i]
@@ -227,8 +225,6 @@ function VirtioNetDevice:map_from_guest (addr)
             self.mem_table[0] = m
          end
          result = addr + m.snabb - m.guest
-         self.last_guest_page = page
-         self.last_guest_offset = m.snabb - m.guest
          break
       end
    end

--- a/src/lib/virtio/virtq.lua
+++ b/src/lib/virtio/virtq.lua
@@ -25,46 +25,39 @@ function VirtioVirtq:new()
    return setmetatable(o, {__index = VirtioVirtq})
 end
 
--- Support indirect descriptors.
-function VirtioVirtq:get_desc()
-   local device = self.device
-   local ring_desc = self.virtq.desc
-   local function indirect_descriptors_negotiated()
-      return band(device.features, C.VIRTIO_RING_F_INDIRECT_DESC) == 
-                     C.VIRTIO_RING_F_INDIRECT_DESC
-   end
-   if (indirect_descriptors_negotiated()) then
-      return function(id)
-         if band(ring_desc[id].flags, C.VIRTIO_DESC_F_INDIRECT) == 0 then
-            return ring_desc, id
-         else
-            local addr = device.map_from_guest(device, ring_desc[id].addr)
-            return ffi.cast(vring_desc_ptr_t, addr), 0
-         end
-      end
+function VirtioVirtq:enable_indirect_descriptors ()
+   self.get_desc = self.get_desc_indirect
+end
+
+function VirtioVirtq:get_desc_indirect (id)
+   if band(ring_desc[id].flags, C.VIRTIO_DESC_F_INDIRECT) == 0 then
+      return ring_desc, id
    else
-      return function(id)
-         return ring_desc, id 
-      end
+      local addr = device.map_from_guest(device, ring_desc[id].addr)
+      return ffi.cast(vring_desc_ptr_t, addr), 0
    end
 end
+
+function VirtioVirtq:get_desc_direct (id)
+   return self.virtq.desc, id 
+end
+
+-- Default: don't support indirect descriptors unless
+-- enable_indirect_descriptors is called to replace this binding.
+VirtioVirtq.get_desc = VirtioVirtq.get_desc_direct
 
 -- Receive all available packets from the virtual machine.
 function VirtioVirtq:get_buffers (kind, ops, header_len)
 
-   local ring = self.virtq.avail.ring
    local device = self.device
    local idx = self.virtq.avail.idx
    local avail, vring_mask = self.avail, self.vring_num-1
 
-   -- Cache function for obtaining ring descriptor.
-   local get_desc = self:get_desc()
-
    while idx ~= avail do
 
       -- Header
-      local v_header_id = ring[band(avail,vring_mask)]
-      local desc, id = get_desc(v_header_id)
+      local v_header_id = self.virtq.avail.ring[band(avail,vring_mask)]
+      local desc, id = self:get_desc(v_header_id)
 
       local data_desc = desc[id]
 


### PR DESCRIPTION
This branch contains work-in-progress optimizations.

The effect on `interlaken.snabb.co` is to increase performance from ~2.0 Mpps to ~4.2 Mpps. I hope the effect will be similar on grindelwald.

These changes mostly tweak LuaJIT behaviour to avoid interpreted mode and garbage collection. Some are sane, some are mysterious, some are oversimplified, but all are effective in my measurements.

@n-nikolaev and @dpino please let me know how this works for you!
