### PR TITLE
core.memory: Use shm (POSIX shared memory) to allocate HugeTLB

### DIFF
--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -1,4 +1,4 @@
 int      lock_memory();
-void    *allocate_huge_page(int size, bool persistent);
+void    *allocate_huge_page(int size);
 uint64_t phys_page(uint64_t virt_page);
 

--- a/src/core/memory.lua
+++ b/src/core/memory.lua
@@ -55,7 +55,7 @@ end
 
 function allocate_hugetlb_chunk ()
    for i =1, 3 do
-      local page = C.allocate_huge_page(huge_page_size, false)
+      local page = C.allocate_huge_page(huge_page_size)
       if page ~= nil then return page else reserve_new_page() end
    end
 end
@@ -89,7 +89,10 @@ huge_page_bits = math.log(huge_page_size, 2)
 
 local uint64_t = ffi.typeof("uint64_t")
 function virtual_to_physical (virt_addr)
-   return bit.band(ffi.cast(uint64_t, virt_addr), 0x0FFFFFFFFFFFULL);
+   local u64 = ffi.cast(uint64_t, virt_addr)
+   assert(bit.band(u64, 0x500000000000ULL) == 0x500000000000ULL,
+	  "virtual address DMA tag check")
+   return bit.bxor(u64, 0x500000000000ULL)
 end
 
 --- ### selftest
@@ -101,8 +104,9 @@ function selftest (options)
       io.write("  Allocating a "..(huge_page_size/1024/1024).."MB HugeTLB: ")
       io.flush()
       local dmaptr, physptr, dmalen = dma_alloc(huge_page_size)
-      print("Got "..(dmalen/1024^2).."MB "..
-         "at 0x"..tostring(ffi.cast("void*",tonumber(physptr))))
+      print("Got "..(dmalen/1024^2).."MB")
+      print("    Physical address: 0x" .. bit.tohex(virtual_to_physical(dmaptr), 12))
+      print("    Virtual address:  0x" .. bit.tohex(ffi.cast(uint64_t, dmaptr), 12))
       ffi.cast("uint32_t*", dmaptr)[0] = 0xdeadbeef -- try a write
       assert(dmaptr ~= nil and dmalen == huge_page_size)
    end


### PR DESCRIPTION
**CAUTION**: The Intel driver selftest is flaky for me at the moment so I have not tested this change as much as I would like.

Quoting the new comment in memory.c:

The HugeTLB page is allocated and mapped using the shm (shared memory) API. This API makes it easy to remap the page to a new virtual address after we resolve the physical address.

There are two other APIs for allocating HugeTLB pages but they do not work as well:

  mmap() anonymous page with MAP_HUGETLB: cannot remap the address after allocation because Linux mremap() does not seem to work on HugeTLB pages.

  mmap() with file-backed MAP_HUGETLB: the file has to be on a hugetlbfs mounted filesystem and that is not necessarily available.

Happily the shm API is happy to remap a HugeTLB page with an additional call to shmat() and does not depend on hugetlbfs.

Further reading:
  https://www.kernel.org/doc/Documentation/vm/hugetlbpage.txt
  http://stackoverflow.com/questions/27997934/mremap2-with-hugetlb-to-change-virtual-address
