### PR TITLE
Port lib.protocol.datagram and dependent apps to straightline core.packet API

### DIFF
--- a/src/apps/ipv6/nd_light.lua
+++ b/src/apps/ipv6/nd_light.lua
@@ -106,7 +106,6 @@ function nd_light:new (arg)
    local nh = { nsent = 0 }
    local dgram = datagram:new()
    nh.packet = dgram:packet()
-   packet.tenure(nh.packet)
    local sol_node_mcast = ipv6:solicited_node_mcast(conf.next_hop)
    local ipv6 = ipv6:new({ next_header = 58, -- ICMP6
 	 hop_limit = 255,
@@ -138,7 +137,7 @@ function nd_light:new (arg)
 		    local nh = o._next_hop
 		    print(string.format("Sending neighbor solicitation for next-hop %s",
 					ipv6:ntop(conf.next_hop)))
-		    link.transmit(o.output.south, nh.packet)
+		    link.transmit(o.output.south, packet.clone(nh.packet))
 		    nh.nsent = nh.nsent + 1
 		    if nh.nsent <= o._config.retrans and not o._eth_header then
 		       timer.activate(nh.timer)
@@ -155,7 +154,6 @@ function nd_light:new (arg)
    local sna = {}
    dgram = datagram:new()
    sna.packet = dgram:packet()
-   packet.tenure(sna.packet)
    -- Leave dst address unspecified.  It will be set to the source of
    -- the incoming solicitation
    ipv6 = ipv6:new({ next_header = 58, -- ICMP6
@@ -170,18 +168,17 @@ function nd_light:new (arg)
    dgram:payload(na:header(), na:sizeof())
    local mem, length = dgram:payload(tgt_lladdr_tlv, tgt_lladdr_tlv_len)
    icmp:checksum(mem, length, ipv6)
-   dgram:push(icmp, true)
+   dgram:push(icmp)
    ipv6:payload_length(icmp:sizeof() + na:sizeof() + tgt_lladdr_tlv_len)
-   dgram:push(ipv6, true)
+   dgram:push(ipv6)
    -- Leave dst address unspecified.
-   local eth = ethernet:new({ src = conf.local_mac,
-			      type = 0x86dd })
-   dgram:push(eth, true)
-   -- These headers are relocated to the packet buffer in order to be
-   -- able to set the destination addresses and ICMP checksum later on.
-   sna.eth = eth
-   sna.ipv6 = ipv6
-   sna.icmp = icmp
+   dgram:push(ethernet:new({ src = conf.local_mac,
+                             type = 0x86dd }))
+   -- Parse the headers we want to modify later on from our template
+   -- packet.
+   dgram = dgram:reuse(sna.packet, ethernet)
+   dgram:parse_n(3)
+   sna.eth, sna.ipv6, sna.icmp = unpack(dgram:stack())
    sna.dgram = dgram
    o._sna = sna
    return o
@@ -238,9 +235,7 @@ local function na (self, dgram, eth, ipv6, icmp)
 end
 
 local function from_south (self, p)
-   local iov = p.iovecs[0]
-   if not self._filter:match(iov.buffer.pointer + iov.offset,
-			     iov.length) then
+   if not self._filter:match(packet.data(p), packet.length(p)) then
       return false
    end
    local dgram = datagram:new(p, ethernet)
@@ -275,11 +270,11 @@ function nd_light:push ()
       local status = from_south(self, p)
       if status == nil then
 	 -- Discard
-	 packet.deref(p)
+	 packet.free(p)
       elseif status == true then
 	 -- Send NA back south
-	 packet.deref(p)
-	 link.transmit(l_reply, self._sna.packet)
+	 packet.free(p)
+	 link.transmit(l_reply, packet.clone(self._sna.packet))
       else
 	 -- Send transit traffic up north
 	 link.transmit(l_out, p)
@@ -292,12 +287,19 @@ function nd_light:push ()
       if not self._eth_header then
 	 -- Drop packets until ND for the next-hop
 	 -- has completed.
-	 packet.deref(link.receive(l_in))
+	 packet.free(link.receive(l_in))
       else
 	 local p = link.receive(l_in)
-	 local iov = p.iovecs[0]
-	 self._eth_header:copy(iov.buffer.pointer + iov.offset)
-	 link.transmit(l_out, p)
+         if packet.length(p) >= self._eth_header:sizeof() then
+            self._eth_header:copy(packet.data(p))
+            link.transmit(l_out, p)
+         else packet.free(p) end
       end
    end
+end
+
+-- Free static packets on `stop'.
+function nd_light:stop ()
+   packet.free(self._next_hop.packet)
+   packet.free(self._sna.packet)
 end

--- a/src/apps/ipv6/ns_responder.lua
+++ b/src/apps/ipv6/ns_responder.lua
@@ -29,7 +29,7 @@ function ns_responder:new(config)
    assert(filter, errmsg and ffi.string(errmsg))
    o._filter = filter
    o._dgram = datagram:new()
-   packet.deref(o._dgram:packet())
+   packet.free(o._dgram:packet())
    return o
 end
 
@@ -96,11 +96,11 @@ function ns_responder:push()
    l_out = self.output.north
    local l_reply = self.output.south
    while not link.empty(l_in) and not link.full(l_out) do
-      local p = packet.want_modify(link.receive(l_in))
+      local p = link.receive(l_in)
       local status = process(self, p)
       if status == nil then
 	 -- Discard
-	 packet.deref(p)
+	 packet.free(p)
       elseif status == true then
 	 -- Send NA back south
 	 link.transmit(l_reply, p)

--- a/src/apps/socket/raw.lua
+++ b/src/apps/socket/raw.lua
@@ -27,7 +27,7 @@ function RawSocket:push ()
    while not link.empty(l) and self.dev:can_transmit() do
       local p = link.receive(l)
       self.dev:transmit(p)
-      packet.deref(p)
+      packet.free(p)
    end
 end
 

--- a/src/apps/socket/raw.lua
+++ b/src/apps/socket/raw.lua
@@ -31,7 +31,7 @@ function RawSocket:push ()
    end
 end
 
-function RawSocket.selftest ()
+function selftest ()
    -- Send a packet over the loopback device and check
    -- that it is received correctly.
    -- XXX beware of a race condition with unrelated traffic over the

--- a/src/apps/vpn/vpws.lua
+++ b/src/apps/vpn/vpws.lua
@@ -61,7 +61,7 @@ function vpws:new(arg)
    assert(filter, errmsg and ffi.string(errmsg))
    o._filter = filter
    o._dgram = datagram:new()
-   packet.deref(o._dgram:packet())
+   packet.free(o._dgram:packet())
    return o
 end
 
@@ -114,12 +114,12 @@ function vpws:push()
 		  valid = false
 	       end
 	       if not valid then
-		  packet.deref(p)
+		  packet.free(p)
 		  p = nil
 	       end
 	    else
 	       -- Packet doesn't belong to VPN, discard
-	       packet.deref(p)
+	       packet.free(p)
 	       p = nil
 	    end
 	 end

--- a/src/apps/vpn/vpws.lua
+++ b/src/apps/vpn/vpws.lua
@@ -102,7 +102,7 @@ function vpws:push()
 		     local key = gre:key()
 		     if ((self._config.label and key and key == self._config.label) or
 		      not (self._config.label or key)) then
-			datagram:pop()
+			datagram:pop(1)
 		     else
 			print(self:name()..": GRE key mismatch: local "
 			   ..(self._config.label or 'none')..", remote "..(gre:key() or 'none'))

--- a/src/core/packet.lua
+++ b/src/core/packet.lua
@@ -78,6 +78,12 @@ function free (p)
    freelist_add(packets_fl, p)
 end
 
+-- Return pointer to packet data.
+function data (p) return p.data end
+
+-- Return packet data length.
+function length (p) return p.length end
+
 --preallocate packets freelist
 if freelist_nfree(packets_fl) == 0 then
    for i=1, max_packets do

--- a/src/lib/protocol/datagram.lua
+++ b/src/lib/protocol/datagram.lua
@@ -11,30 +11,17 @@
 --
 --   Creation of a new packet
 --
--- This functionality is provided by keeping track of two separate
--- header stacks, called the "parse stack" and the "push stack".  The
--- parse stack is built from the data contained in an existing packet
--- while the push stack is built from newly created protocol headers.
-
--- The datagram object keeps track of the start of the yet unparsed
--- portion of a packet by storing the index of the iovec and the
--- offset relative to the iovec's offset into the buffer.  By
--- definition, the unparsed portion of a packet is called the payload
--- at any point in time, i.e. once a header is parsed, it is no longer
--- part of the payload.
+-- It keeps track of a "parse stack" consisting of an (indexed) stack of
+-- header objects and an offset into the packet.
 --
--- When a new datagram is created, the index and offset are both
--- initialized to zero, such that parsing starts at the beginning of
--- the packet and the entire packet is considered as payload.
+-- When a new datagram is created, the parse stack index and the offset
+-- are both initialized to zero, such that parsing starts at the
+-- beginning of the packet and the entire packet is considered as
+-- payload.
 --
 -- When one of the parser methods is called, the offset is advanced by
 -- the size of the parsed header (and the payload reduced
 -- correspondingly).
---
--- It is important to note that parsing is currently restricted to a
--- single buffer.  If the total size of a multi-buffer packet is not
--- larger than a single buffer, the buffers can be coalesced into one
--- by passing the "coalesce" option to the datagram constructor.
 --
 -- Also note that parsing does not change the packet itself.  However,
 -- the header at the bottom of the parse stack (which is located at
@@ -42,28 +29,10 @@
 -- packet by calling the pop() method, which advances the iovec's
 -- offset accordingly.
 --
--- The push stack works differently.  First of all, it is important to
--- note that it grows downwards, i.e. inner headers must be pushed
--- onto the packet before outer headers.  The push mechanism always
--- works on iovec #0.  When this iovec has no room to store the new
--- header adjacent to the beginning of the buffer's valid data, a new
--- buffer is prepended to the packet.  The offset of the new iovec is
--- then set to the size of the buffer to allow downward growth.  When
--- this happens, the iovec index of the parse stack is increased by
--- one to account for the new buffer.
---
--- This on-demand allocation minimizes the number of newly created
--- buffers even if different apps push headers to the same packet.
---
--- By default, when a header is pushed onto a packet, the header data
--- is only copied into the packet, i.e. changes to the header object
--- after the fact are not represented in the packet.  It is also
--- possible to relocate the header object's data to the packet buffer,
--- such that changes to the object are reflected in the packet.  This
--- is useful if certain header fields need to be updated after the
--- header has been pushed.  However, the application must then make
--- sure that the header object is discarded when the packet buffer is
--- released.
+-- The push() method can be used to prepend headers in front of the
+-- packet. IMPORTANT: Both pop() and push() destructively modify the
+-- packet and headers previously obtained by calls to parse_*() will be
+-- corrupted.
 --
 -- To construct a packet from scratch, the constructor is called
 -- without a reference to a packet.  In this case, a new packet is
@@ -81,11 +50,9 @@ local datagram = subClass(nil)
 -- Create a datagram from a packet or from scratch (if p == nil).  The
 -- class argument is only relevant for parsing and can be set to the
 -- header class of the the outermost packet header.  
-local function init (o, p, class, options)
+local function init (o, p, class)
    if not o._recycled then
       o._parse = { stack = {}, index = 0 }
-      o._packet = ffi.new("struct packet *[1]")
-      o._opt_default = { coalesce = false }
    elseif o._parse.stack[1] then
       for i, _ in ipairs(o._parse.stack) do
 	 o._parse.stack[i]:free()
@@ -93,54 +60,29 @@ local function init (o, p, class, options)
       end
       o._parse.index = 0
    end
-   o._opt = options or o._opt_default
-   o._parse.ulp = class
-   if p then
-      if o._opt.coalesce then
-	 packet.coalesce(p)
-      end
-      o._packet[0] = p
-   else
-      o._packet[0] = packet.allocate()
-      local b = buffer.allocate()
-      packet.add_iovec(o._packet[0], b, 0)
-   end
-   o._parse.iovec = 0
    o._parse.offset = 0
+   o._parse.ulp = class
+   o._packet = p or packet.allocate()
    return o
 end
 
-function datagram:new (p, class, options)
-   return(init(datagram:superClass().new(self), p, class, options))
+function datagram:new (p, class)
+   return(init(datagram:superClass().new(self), p, class))
 end
 
--- Reuse an existing object to avoid putting it on the freelist
-function datagram:reuse (p, class, options)
+-- Reuse an existing object to avoid putting it on the freelist.
+-- Caution: This will free the datagram's current packet.
+function datagram:reuse (p, class)
    self._recycled = true
-   return(init(self, p, class, options))
+   return(init(self, p, class))
 end
 
 -- Instance methods
 
--- Push a new protocol header to the front of the packet, i.e. the
--- buffer of iovec #0.  If there is no room for the header, a new
--- buffer is prepended to the packet first.  If relocate is a false
--- value, the protocol's header is copied to the packet.  If it is a
--- true value, the protocol's header is relocated to the buffer
--- instead.
-function datagram:push (proto, relocate)
-   local iov = self._packet[0].iovecs[0]
-   local sizeof = proto:sizeof()
-   if sizeof > iov.offset then
-      -- Header doesn't fit, allocate a new buffer
-      local b = buffer.allocate()
-      packet.prepend_iovec(self._packet[0], b, 0, b.size)
-      self._parse.iovec = self._parse.iovec+1
-   end
-   proto:copy(iov.buffer.pointer + iov.offset - sizeof, relocate)
-   iov.offset = iov.offset - sizeof
-   iov.length = iov.length + sizeof
-   self._packet[0].length = self._packet[0].length + sizeof
+-- Push a new protocol header to the front of the packet.
+function datagram:push (proto)
+   packet.prepend(self._packet, proto:header(), proto:sizeof())
+   self._parse.offset = self._parse.offset + proto:sizeof()
 end
 
 -- The following methods create protocol header objects from the
@@ -170,13 +112,9 @@ end
 function datagram:parse_match (class, check)
    local parse = self._parse
    local class = class or parse.ulp
-   local iovec = self._packet[0].iovecs[parse.iovec]
-
-   if not class then
-      return nil
-   end
-   local proto = class:new_from_mem(iovec.buffer.pointer + iovec.offset
-                                    + parse.offset, iovec.length - parse.offset)
+   if not class then return nil end
+   local proto = class:new_from_mem(packet.data(self._packet) + parse.offset,
+                                    packet.length(self._packet) - parse.offset)
    if proto == nil or (check and not check(proto)) then
       if proto then proto:free() end
       return nil
@@ -237,24 +175,17 @@ function datagram:unparse (n)
    end
 end
 
--- Remove the bottom n elements from the parse stack by adjusting the
--- offset of the relevant iovec.
+-- Remove the bytes of the bottom <n> headers from the parse stack from
+-- the start of the packet.
 function datagram:pop (n)
-   local n = n or 1
    local parse = self._parse
+   local n_bytes = 0
    assert(n <= parse.index)
-   local proto
-   local iovec = self._packet[0].iovecs[parse.iovec]
-   -- Don't use table.remove to avoid garbage
    for i = 1, parse.index do
       if i <= n then
-	 proto = parse.stack[i]
-	 local sizeof = proto:sizeof()
+	 local proto = parse.stack[i]
+         n_bytes = n_bytes + proto:sizeof()
 	 proto:free()
-	 iovec.offset = iovec.offset + sizeof
-	 iovec.length = iovec.length - sizeof
-	 self._packet[0].length = self._packet[0].length - sizeof
-	 parse.offset = parse.offset - sizeof
       end
       if i+n <= parse.index then
 	 parse.stack[i] = parse.stack[i+n]
@@ -263,22 +194,15 @@ function datagram:pop (n)
       end
    end
    parse.index = parse.index - n
+   self:pop_raw(n_bytes)
+   self._parse.offset = self._parse.offset - n_bytes
 end
 
--- Remove <length> bytes from the start of the packet.  It is intended
--- as an efficient version of pop() if the caller already knows what
--- type of header is at the start of the packet, for example after a
--- successful match of matcher:compare().  If the caller also knows
--- the type of the subsequent header, it can pass the corresponding
--- protocol class as second argument to pop_raw().  This will set the
--- datagram's upper-layer protocol to this class such that the parse()
--- method can be used to process the datagram further.
+-- Remove <length> bytes from the start of the packet and set upper-layer
+-- protocol to <ulp> if <ulp> is supplied.
 function datagram:pop_raw (length, ulp)
-   local iovec = self._packet[0].iovecs[self._parse.iovec]
-   iovec.offset = iovec.offset + length
-   iovec.length = iovec.length - length
-   self._packet[0].length = self._packet[0].length - length
-   self._parse.ulp = ulp
+   packet.shiftleft(self._packet, length)
+   if ulp then self._parse.ulp = ulp end
 end
 
 function datagram:stack ()
@@ -286,34 +210,16 @@ function datagram:stack ()
 end
 
 function datagram:packet ()
-   return(self._packet[0])
+   return(self._packet)
 end
 
 -- Return the location and size of the packet's payload.  If mem is
 -- non-nil, the memory region at the given address and size is
--- appended to the packet's payload first.  Because parsing is
--- restricted to a single buffer, it is possible that additional
--- buffers exist beyond the parse buffer.  In this case, the payload
--- is not complete.  This is communicated to the caller by a third
--- return value, which is a true value if the payload is complete and
--- a false value if not.
+-- appended to the packet's payload first.
 function datagram:payload (mem, size)
-   local parse = self._parse
-   local iovec = self._packet[0].iovecs[parse.iovec]
-   local payload = iovec.buffer.pointer + iovec.offset + parse.offset
-   local multi_buffer_p = parse.iovec ~= self._packet[0].niovecs - 1
-   if mem ~= nil then
-      assert(size <= iovec.buffer.size - (iovec.offset + iovec.length),
-             "not enough space in buffer to add payload")
-      assert(not multi_buffer_p,
-             "can not add payload to multi-buffer packet")
-      ffi.copy(iovec.buffer.pointer + iovec.offset + iovec.length,
-               mem, size)
-      iovec.length = iovec.length + size
-      self._packet[0].length = self._packet[0].length + size
-   end
-   local p_size = iovec.length - parse.offset
-   return payload, p_size, (multi_buffer_p and parse.iovec + 1) or nil
+   if mem then packet.append(self._packet, mem, size) end
+   return packet.data(self._packet) + self._parse.offset,
+          packet.length(self._packet) - self._parse.offset
 end
 
 return datagram


### PR DESCRIPTION
This adds accessors for packet length and data to `core.packet` (in order to avoid using the potentially implementation specific struct slots `length` and `data`.

The `lib.protocol.datagram` library is translated to use the new `core.packet`. Dependent apps are updated (as conservatively as possible).
