### PR TITLE
intel_app: Recode while-loop as for-loop

### DIFF
--- a/src/apps/intel/intel_app.lua
+++ b/src/apps/intel/intel_app.lua
@@ -74,12 +74,11 @@ end
 -- Pull in packets from the network and queue them on our 'tx' link.
 function Intel82599:pull ()
    local l = self.output.tx
-   local n = 128
    if l == nil then return end
    self.dev:sync_receive()
-   while not full(l) and self.dev:can_receive() and n>0 do
+   for i=1,128 do
+      if full(l) or not self.dev:can_receive() then break end
       transmit(l, self.dev:receive())
-      n = n - 1
    end
    self:add_receive_buffers()
 end


### PR DESCRIPTION
Recoding the while-loop in `Intel82599:pull()` as a for-loop improves performance slightly as commented in https://github.com/lukego/snabbswitch/commit/befba8ec1b64f04d3cdee6c6a2f5a750717169e8.

Here are my tests:

**straightline** (last commit: 11a334523)

Rate(Mpps): 3.237
Rate(Mpps): 3.255
Rate(Mpps): 3.288
Rate(Mpps): 3.246
Rate(Mpps): 3.263

**patch applied**

Rate(Mpps): 3.686
Rate(Mpps): 3.407
Rate(Mpps): 3.676
Rate(Mpps): 3.676
Rate(Mpps): 3.415

The performance also improves if the number of packets pulled is set to a number higher than 128:

**192**

Rate(Mpps): 3.962
Rate(Mpps): 3.731
Rate(Mpps): 3.708
Rate(Mpps): 3.951
Rate(Mpps): 3.722

**256**

Rate(Mpps): 3.993
Rate(Mpps): 3.864
Rate(Mpps): 3.997
Rate(Mpps): 4.006
Rate(Mpps): 3.998

Above 256 there are not significant improvements. As for now I'd leave it as it is, 128, and if it makes sense set it to a higher number in a later patch.

I think it'd be good to check the patch provides the same results in other NICs. My environment is grindelwald working on NIC 05.
